### PR TITLE
Improve error reports from web app

### DIFF
--- a/lib/db_agent/seeder.rb
+++ b/lib/db_agent/seeder.rb
@@ -25,7 +25,10 @@ module DbAgent
         pairs.keys.each do |table|
           LOGGER.info("Filling table `#{table}`")
           file = pairs[table]
-          handler.sequel_db[table].multi_insert(file.load)
+          data = file.load
+          raise "Empty file: #{file}" if data.nil?
+
+          handler.sequel_db[table].multi_insert(data)
         end
 
         after_seeding!(folder)

--- a/lib/db_agent/webapp.rb
+++ b/lib/db_agent/webapp.rb
@@ -1,10 +1,17 @@
 module DbAgent
   class Webapp < Sinatra::Base
 
-    set :raise_errors, true
+    set :raise_errors, false
     set :show_exceptions, false
     set :dump_errors, true
     set :db_handler, DbAgent.default_handler
+
+    error do
+      route = env['sinatra.route']
+      params = env['sinatra.error.params']
+      error = env['sinatra.error']
+      "DbAgent (route: #{route} | params: #{params}) error: #{error.message}\n#{error.backtrace[0..10]}\n\n"
+    end
 
     get '/ping' do
       settings.db_handler.sequel_db.test_connection


### PR DESCRIPTION
  * Don't return HTML
  * Instead return plain text error with most important info
  * Seeder: raise on empty files